### PR TITLE
Add importlib-metadata temporarily to fix pip check.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - folium
     - gdal >=2.1.0
     - geojson
+    - importlib-metadata  # [py37] # undefined upstream requirement (see https://github.com/conda-forge/filesystem-spec-feedstock/pull/43)
     - matplotlib-base
     - numpy
     - pandas


### PR DESCRIPTION
Temporarily added importlib-metadata (undefined in fsspec 0.9.0) to fix `pip check` in https://github.com/conda-forge/geoarray-feedstock/pull/26 and https://github.com/conda-forge/geoarray-feedstock/pull/27. As soon as https://github.com/conda-forge/filesystem-spec-feedstock/pull/43 is solved, this can be removed.